### PR TITLE
Rule "disallowMultipleLineStrings" was set twice.

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -57,7 +57,6 @@
     "disallowCommaBeforeLineBreak": null,
     "disallowDanglingUnderscores": null,
     "disallowEmptyBlocks": null,
-    "disallowMultipleLineStrings": null,
     "disallowTrailingComma": null,
     "requireCommaBeforeLineBreak": null,
     "requireDotNotation": null,


### PR DESCRIPTION
The rule "disallowMultipleLineStrings" was set twice. 

The first on line 23 was set to "true", and the second on line 60 was set to "null". 

I deleted the line 60 "null" rule, leaving the rule set to "true".
